### PR TITLE
Cambios en createEmarkingActivity y se agrega nueva función IdEmarkingActivity

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -114,7 +114,6 @@ class AcceptanceTester extends \Codeception\Actor
     	
     	
     	//Grade
-    	$this->selectOption('gradecat',$info['gradecat']);
     	$this->selectOption('grademin',$info['grademin']);
     	$this->selectOption('grade',$info['grade']);
     	
@@ -135,5 +134,16 @@ class AcceptanceTester extends \Codeception\Actor
     	$this->seeLink($info['name']);
     	
     }
+
+    public function IdEmarkingActivity($curse, $activity){
     
+    	$this->see($curse);    	
+    	$this->click($curse);
+    	
+    	$this->see($activity);
+    	$this->click($activity);
+    	
+    	$activityId = $this->grabFromCurrentUrl('/id=(\d+)/');
+    	return $activityId;
+    }
 }

--- a/tests/acceptance/02Emarking/06CreateEmarkingActivityCept.php
+++ b/tests/acceptance/02Emarking/06CreateEmarkingActivityCept.php
@@ -33,7 +33,6 @@ $I->createEmarkingActivity($info= array(
 		'regradesclosedateminute' => '10',
 		'peervisibility' => 'Yes',
 		
-		'gradecat' => '1',
 		'grademin' => '0',
 		'grade' => '7',
 

--- a/tests/acceptance/02Emarking/08IdEmarkingActivityCept.php
+++ b/tests/acceptance/02Emarking/08IdEmarkingActivityCept.php
@@ -1,0 +1,10 @@
+<?php
+$I = new AcceptanceTester($scenario);
+
+$I->wantTo('Create a Rubirc for a Emarking activiy');
+
+$I->login('admin','pepito.P0','Admin User');
+
+$activityId = $I->IdEmarkingActivity('Test Course Sec.1 2015', 'test1');
+
+?>


### PR DESCRIPTION
AcceptanceTester.php
- Se elimino en la función "createEmarkingActivity" la selección del gradecat puesto que este es estándar
- Se le agrego la función para rescatar el id de una actividad en un
  curso X

06CreateEmarkingActivityCept.php
- Se elimino la variable $gradecat puesto que esta es de un único valor

08IdEmarkingActivity
- Se agrego esta nueva actividad para poder rescatar alguna la id de una
  actividad Y en algun curso X
